### PR TITLE
Add Dokime: open-source ML training data quality toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ This section covers comprehensive data management approaches for LLMs, including
 - [CommonCrawl](https://commoncrawl.org/) - A massive web crawl dataset covering diverse languages and domains. (2008)
 - [RedPajama](https://github.com/togethercomputer/RedPajama-Data) - An open-source reproduction of the LLaMA training dataset. (2023)
 - [FineWeb](https://huggingface.co/datasets/HuggingFaceFW/fineweb) - A large-scale, high-quality web dataset for language model training. (2024)
+- [Dokime](https://github.com/dokime-ai/dokime) - An open-source CLI toolkit for scoring, filtering, deduplicating, and diagnosing ML training data quality. (2026)
 
 ### Cognition Engineering & Test-Time Scaling
 


### PR DESCRIPTION
Added [Dokime](https://github.com/dokime-ai/dokime) to the LLM Data Management > Tools & Projects section.

Dokime is an open-source CLI toolkit for ML training data quality:
- Quality scoring (grade datasets A-F)
- 12 heuristic filters (composable via code or YAML)
- 3 dedup strategies (exact, fuzzy, semantic)
- Full diagnostic command (`dokime diagnose`)
- CI/CD integration (`--json` output)

PyPI: `pip install dokime` | GitHub: https://github.com/dokime-ai/dokime